### PR TITLE
Additionally add customer ID and customer emails (if multiple) to the…

### DIFF
--- a/Http/Controllers/SidebarWebhookController.php
+++ b/Http/Controllers/SidebarWebhookController.php
@@ -83,7 +83,9 @@ class SidebarWebhookController extends Controller
                 }
 
                 $payload = [
+                    'customerId'          => $customer->id,
                     'customerEmail'       => $customer->getMainEmail(),
+                    'customerEmails'      => $customer->emails->pluck('email')->toArray(),
                     'customerPhones'      => $customer->getPhones(),
                     'conversationSubject' => $conversation->getSubject(),
                     'conversationType'    => $conversation->getTypeName(),

--- a/README.md
+++ b/README.md
@@ -42,9 +42,14 @@ Other installations are possible, but not supported here.
 Your webhook server will receive a POST request with this kind of JSON body:
 ```json
 {
+    "customerId": 123,
     "conversationSubject": "Testing this sidebar",
     "conversationType": "Phone",
     "customerEmail": "hello@example.com",
+    "customerEmails": [
+      "hello@example.com",
+      "welcome@example.com"
+    ],
     "customerPhones": [{
 	    "n": "",
       "type": 1,
@@ -106,4 +111,4 @@ After you have checked all these things, please create an issue and detail how y
 
 ## Inspiration
 
-* This project was inspired by [Sidebar API](https://scoutdevs.com/downloads/sidebar-api/).
+* This project was inspired by [Sidebar API](https://github.com/scout-devs/SidebarApi).


### PR DESCRIPTION
These changes do not change the current params so should be backwards compatible.

These changes add the customer id and all user emails as an array to the POST request.

I also updated the readme example and changed the broken link on the bottom of the readme.

I would love these changes to be merged for the next release, if you have any issues with them please let me know and I can adjust things.

Thanks,

Stiofan