### PR TITLE
add conversation id and number to webhook payload.

### DIFF
--- a/Http/Controllers/SidebarWebhookController.php
+++ b/Http/Controllers/SidebarWebhookController.php
@@ -89,6 +89,8 @@ class SidebarWebhookController extends Controller
                     'customerPhones'      => $customer->getPhones(),
                     'conversationSubject' => $conversation->getSubject(),
                     'conversationType'    => $conversation->getTypeName(),
+                    'conversationId'      => $conversation->id,
+                    'conversationNumber'  => $conversation->number,
                     'mailboxId'           => $mailbox->id,
                     'secret'              => empty($secret) ? '' : $secret,
                 ];


### PR DESCRIPTION
Hi, first of all thanks for the great work with this module.

What do you think about adding the conversation id and number to the webhook payload?
I personally find this information very useful for example when interacting with the fs api from the sidebar.

BR
Paul