### PR TITLE
add timeout to prevent freescout from freezing when endpoint is not reachable

### DIFF
--- a/Http/Controllers/SidebarWebhookController.php
+++ b/Http/Controllers/SidebarWebhookController.php
@@ -103,6 +103,9 @@ class SidebarWebhookController extends Controller
                             'Accept' => 'text/html',
                         ],
                         'body' => json_encode($payload),
+                        'connect_timeout' => 5,
+                        'timeout' => 10,
+                        'http_errors' => true,
                     ]);
                     $response['html'] = $result->getBody()->getContents();
                     $response['status'] = 'success';


### PR DESCRIPTION
Hi, thanks again for this nice extension.

While running in production we ran into a problem that the whole fs freezes, because the webhook endpoint was not reachable. It locks up php workers until there are none left.

I added a timeout to the post request to fail quicker than `max_execution_time`.

BR Paul